### PR TITLE
UTextComponent: Fix appending text components with hover events

### DIFF
--- a/src/main/kotlin/gg/essential/universal/wrappers/message/UTextComponent.kt
+++ b/src/main/kotlin/gg/essential/universal/wrappers/message/UTextComponent.kt
@@ -173,9 +173,15 @@ class UTextComponent : MCITextComponent {
         //$$ val event = HoverEvent<MCITextComponent>(action, value)
         //$$ setHoverEventHelper(event)
         //#else
+        val value: MCITextComponent = when (hoverValue) {
+            is String -> MCStringTextComponent(hoverValue as String)
+            is UTextComponent -> (hoverValue as UTextComponent).component
+            is MCITextComponent -> hoverValue as MCITextComponent
+            else -> MCStringTextComponent(hoverValue.toString())
+        }
         setHoverEventHelper(HoverEvent(
             hoverAction,
-            MCStringTextComponent(hoverValue!! as String)
+            value
         ))
         //#endif
     }


### PR DESCRIPTION
UTextComponent's hover value has a type of Any? but performs an unchecked cast on all cases to String.

Appending any MCITextComponent causes a ClassCastException because a MCITextComponent is passed